### PR TITLE
Add @doctest as an alias to doctest.

### DIFF
--- a/doc/special_directives.doctest
+++ b/doc/special_directives.doctest
@@ -12,9 +12,13 @@ This directive splits your irb sessions into logical "test units" with descripti
 
 	doctest: This is the first test.  Is this document up to date with the code?
 	>> RubyDocTest::SpecialDirective::NAMES
-	=> ["doctest:", "it:", "!!!", "doctest_require:"]
+	=> ["doctest:", "@doctest", "it:", "!!!", "doctest_require:"]
 
 Any irb sessions appearing before the first doctest: directive will be included in an all-encompassing "Default Test".  If you have no "doctest:" directives anywhere in your document, then all irb statements will be placed in the "Default Test".
+
+For compatibility with YARD, we provide `@doctest`, which is an alias for `doctest:`.
+Note that `@doctest` does not support multi-line test description,
+for compatibility with YARD.
 
 ### The "!!!" Directive
 

--- a/lib/special_directive.rb
+++ b/lib/special_directive.rb
@@ -5,7 +5,7 @@ require 'lines'
 
 module RubyDocTest
   class SpecialDirective < Lines
-    NAMES = ["doctest:", "it:", "!!!", "doctest_require:"]
+    NAMES = ["doctest:", "@doctest", "it:", "!!!", "doctest_require:"]
     NAMES_FOR_RX = NAMES.map{ |n| Regexp.escape(n) }.join("|")
     
     # === Test
@@ -14,6 +14,11 @@ module RubyDocTest
     # >> s = RubyDocTest::SpecialDirective.new(["doctest: Testing Stuff", "Other Stuff"])
     # >> s.name
     # => "doctest:"
+    #
+    # doctest: "@doctest" is a valid directive
+    # >> s = RubyDocTest::SpecialDirective.new(["@doctest is an alias."])
+    # >> s.name
+    # => "@doctest"
     #
     # doctest: "it:" is a valid directive
     # >> s = RubyDocTest::SpecialDirective.new(["it: should test stuff"])


### PR DESCRIPTION
Now the following test code works:

For compatibility with YARD, @doctest allows indentations, while
does not allow multiline test description.
