### PR TITLE
Indentation can also include the ' |' mark.

### DIFF
--- a/lib/lines.rb
+++ b/lib/lines.rb
@@ -76,12 +76,16 @@ module RubyDocTest
     # doctest: Indentation can also include the ?> marker
     # >> l.range [">> 1 +", "?> 2"], 0
     # => 0..1
+    #
+    # doctest: Indentation can also include the " |" marker
+    # >> l.range [">> 1 +", " | 2"], 0
+    # => 0..1
     def range(doc_lines = @doc_lines, start_index = @line_index)
       end_index = start_index
       idt = indentation(doc_lines, start_index)
       # Find next lines that are blank, or have indentation more than the first line
       remaining_lines(doc_lines, start_index + 1).each do |current_line|
-        if current_line =~ /^(#{Regexp.escape(idt)}(\s+|\?>\s)|\s*$)/
+        if current_line =~ /^(#{Regexp.escape(idt)}(\s+|(\?>|\|)\s)|\s*$)/
           end_index += 1
         else
           break
@@ -109,7 +113,7 @@ module RubyDocTest
     # => " # "
     def indentation(doc_lines = @doc_lines, line_index = @line_index)
       if doc_lines[line_index]
-        doc_lines[line_index][/^(\s*#\s*|\s*)(\?>\s?)?/]
+        doc_lines[line_index][/^(\s*#\s*|\s*)((\?>|\|)\s?)?/]
       else
         ""
       end

--- a/lib/statement.rb
+++ b/lib/statement.rb
@@ -42,6 +42,11 @@ module RubyDocTest
     # >> s = RubyDocTest::Statement.new([">> b = 1 +", "?> 1"])
     # >> s.source_code
     # => "b = 1 +\n1"
+    #
+    # doctest: Lines indented by " |" should have the " |" removed.
+    # >> s = RubyDocTest::Statement.new([">> b = 1 +", " | 1"])
+    # >> s.source_code
+    # => "b = 1 +\n1"
     def source_code
       lines.first =~ /^#{Regexp.escape(indentation)}>>\s(.*)$/
       first = [$1]


### PR DESCRIPTION
Besides '?>'(irb), indentation can also include the ' |' mark (pry).
