### PR TITLE
Fixed "undefined method `=~' for an instance of Array (NoMethodError)" on Ruby 3.2+

### DIFF
--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -135,7 +135,7 @@ module RubyDocTest
               everything_passed = false
               status = ["FAIL".center(4), :red]
 
-              result_raw = t.first_failed.actual_result
+              result_raw = t.first_failed.actual_result.to_s
               got = if result_raw =~ /\n$/ && result_raw.count("\n") > 1
                       "Got: <<-__END__\n#{result_raw}__END__\n       "
                     else


### PR DESCRIPTION
Since Ruby 3.2, "undefined method `=~' for an instance of Array (NoMethodError)" occurs when a test fails in rubydoctest.

So I fixed.

# Example
## test.md
```ruby
>> [1, 3, 2].sort_by(&:itself)
=> [1, 2, 3]
```

## Ruby 3.1 + rubydoctest v1.1.5
```bash
$ ruby -v
ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [arm64-darwin23]

$ ./bin/rubydoctest /tmp/test.md
=== Testing '/tmp/test.md'...
1.  FAIL | Default Test
           Got:      [1, 2, 3]
           Expected: [1, 3, 2]
             from /tmp/test.md:3
1 comparisons, 1 doctests, 1 failures, 0 errors
```

## Ruby 3.2 + rubydoctest v1.1.5 (Unintentional error!)
```bash
$ ruby -v
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]

$ ./bin/rubydoctest /tmp/test.md
=== Testing '/tmp/test.md'...
/Users/sue445/workspace/github.com/tslocke/rubydoctest/lib/runner.rb:139:in `block in run': undefined method `=~' for [1, 2, 3]:Array (NoMethodError)
	from /Users/sue445/workspace/github.com/tslocke/rubydoctest/lib/runner.rb:124:in `each'
	from /Users/sue445/workspace/github.com/tslocke/rubydoctest/lib/runner.rb:124:in `each_with_index'
	from /Users/sue445/workspace/github.com/tslocke/rubydoctest/lib/runner.rb:124:in `run'
	from -e:8:in `<main>'
```

## Ruby 3.2 + my patch
```bash
$ ruby -v
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]

$ ./bin/rubydoctest /tmp/test.md
=== Testing '/tmp/test.md'...
1.  FAIL | Default Test
           Got:      [1, 2, 3]
           Expected: [1, 3, 2]
             from /tmp/test.md:3
1 comparisons, 1 doctests, 1 failures, 0 errors
```