### PR TITLE
`Gem::Specification#default_executable=` and `Gem::Specification#has_rdoc=` was removed in bundler 4.0.0

### DIFF
--- a/rubydoctest.gemspec
+++ b/rubydoctest.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Duane Johnson", "Tom Locke", "Dr Nic Williams"]
   s.date = "2014-12-31"
-  s.default_executable = "rubydoctest"
   s.description = "Ruby version of Python's doctest tool, but a bit different."
   s.email = ["duane.johnson@gmail.com"]
   s.executables = ["rubydoctest"]
@@ -53,7 +52,6 @@ Gem::Specification.new do |s|
     website/template.html.erb
   MANIFEST
   s.files = manifest.strip.split("\n").map{|m| m.strip}
-  s.has_rdoc = true
   s.homepage = %q{http://rubydoctest.rubyforge.org}
   s.post_install_message = %q{
 rubydoctest comes as an executable that takes a file or directory:


### PR DESCRIPTION
ref.

* https://github.com/ruby/rubygems/pull/9081
* https://github.com/ruby/rubygems/commit/84ceaff1b78c8ccc0b4d18cae23a1630577b0b89
* https://github.com/ruby/rubygems/pull/9084